### PR TITLE
Set fixed version for nokogiri 1.8.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'rack-cors'
 
 gem 'stripe'
 
+gem 'nokogiri', '=1.8.3'
+
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
       railties (>= 3.2, < 6.0)
     erubis (2.7.0)
     eventmachine (1.2.7)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
     foreman (0.85.0)
       thor (~> 0.19.1)
     globalid (0.4.1)
@@ -72,6 +74,7 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
+    libv8 (3.16.14.19)
     libv8 (3.16.14.19-x86_64-linux)
     loofah (2.2.2)
       crass (~> 1.0.2)
@@ -82,6 +85,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
@@ -90,6 +94,7 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.10)
+    rack-cors (1.0.2)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.10)
@@ -140,6 +145,8 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.13)
+    stripe (3.17.0)
+      faraday (~> 0.10)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -164,12 +171,15 @@ DEPENDENCIES
   foreman
   jquery-rails
   less-rails (~> 2.8.0)
+  nokogiri (= 1.8.3)
   protected_attributes
   quiet_assets
+  rack-cors
   rails (~> 4.1, >= 4.1.0)
   sass-rails (~> 4.0.0)
   sdoc
   sqlite3
+  stripe
   therubyracer
   thin
 


### PR DESCRIPTION
Error occurs if you do not do this since 1.8.4 is the default yet we have packages looking for 1.8.3

The error that occurs:

```
/var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/spec_set.rb:91:in `block in materialize': Could not find nokogiri-1.8.3 in any of the sources (Bundler::GemNotFound)
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/spec_set.rb:85:in `map!'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/spec_set.rb:85:in `materialize'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/definition.rb:171:in `specs'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/definition.rb:238:in `specs_for'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/definition.rb:227:in `requested_specs'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/runtime.rb:108:in `block in definition_method'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/runtime.rb:20:in `setup'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler.rb:107:in `setup'
	from /var/lib/gems/2.3.0/gems/bundler-1.16.2/lib/bundler/setup.rb:20:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /opt/app/src/config/boot.rb:4:in `<top (required)>'
	from bin/rake:2:in `require_relative'
	from bin/rake:2:in `<main>'
```