### PR TITLE
Fix bundler and sqlite versions in Dockerfile and Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN apt-get update -qq \
 WORKDIR $APP_PATH
 COPY Gemfile $APP_PATH/
 RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc \
-    && gem update --system \
-    && gem2.3 install bundler --version=1.8.0 \
+    && gem install bundler -v "<2.0" \
     && bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
 
 # # install nodejs dependencies ( in separate dir due to docker cache)

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.3.8'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.1', '>= 4.1.0'
 
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.6'
 
 gem 'thin'
 


### PR DESCRIPTION
Was receiving the following error:

``` 
Bundler could not find compatible versions for gem "bundler":
      In Gemfile:
        rails (= 4.1.8) was resolved to 4.1.8, which depends on
          bundler (< 2.0, >= 1.3.0)

      Current Bundler version:
        bundler (2.0.1)
    This Gemfile requires a different version of Bundler.
    Perhaps you need to update Bundler by running `gem install bundler`?

    Could not find gem 'bundler (< 2.0, >= 1.3.0)', which is required by gem 'rails
    (= 4.1.8)', in any of the sources.
```

I believe this was caused by the call to `bundle update`, which I deleted. Then I specified the necessary bundler version. 